### PR TITLE
#169 Samsung Galaxy Note 3 Chrome Emulation name assignment fixed

### DIFF
--- a/config/browser.properties
+++ b/config/browser.properties
@@ -141,7 +141,7 @@ browserprofile.Safari_1024x768.name = Local Safari 1024x768
 browserprofile.Safari_1024x768.browser = safari
 browserprofile.Safari_1024x768.screenResolution = 1024x768
 
-browserprofile.Galaxy_Note3_Emulation.name Samsung Galaxy Note 3 Chrome Emulation
+browserprofile.Galaxy_Note3_Emulation.name = Samsung Galaxy Note 3 Chrome Emulation
 browserprofile.Galaxy_Note3_Emulation.browser = chrome
 browserprofile.Galaxy_Note3_Emulation.chromeEmulationProfile = Samsung Galaxy Note 3
 


### PR DESCRIPTION
Added a  '=' in the browser config 