### PR TITLE
 #152 Improve DragAndDrop support

### DIFF
--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
 
 import com.codeborne.selenide.AssertionMode;
 import com.codeborne.selenide.Condition;
@@ -410,8 +411,21 @@ public class SelenideAddons
      */
     public static void dragAndDrop(SelenideElement elementToMove, int horizontalMovement, int verticalMovement)
     {
-        // perform drag and drop via the standard Selenium way
-        new Actions(Neodymium.getDriver()).dragAndDropBy(elementToMove.getWrappedElement(), horizontalMovement, verticalMovement).build().perform();
+        try
+        {
+            // perform drag and drop via the standard Selenium way
+            new Actions(Neodymium.getDriver()).dragAndDropBy(elementToMove.getWrappedElement(), horizontalMovement, verticalMovement).build().perform();
+        }
+        catch (MoveTargetOutOfBoundsException targetOutOfBound)
+        {
+            String parameterMessage = horizontalMovement != 0 ? (verticalMovement != 0 ? "'horizontalMovement' and 'verticalMovement'" : "'horizontalMovement'")
+                                                              : "'verticalMovement'";
+
+            throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                        new AssertionError("Target out of bounds. Try to decrease the absolute value of " + parameterMessage
+                                                           + " parameter", targetOutOfBound),
+                                        0);
+        }
     }
 
     /**

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
@@ -420,11 +419,8 @@ public class SelenideAddons
         catch (MoveTargetOutOfBoundsException targetOutOfBound)
         {
             String message = "Performing drag and drop with an element moved the element out of the viewport. Try to scroll the element completely into the view port or to decrease the absolute values of your movements.";
-            SelenideLogger.commitStep(SelenideLogger.beginStep("slider", message),
-                                      targetOutOfBound);
-            throw new RuntimeException(UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                             new WebDriverException(message, targetOutOfBound),
-                                                             0));
+            SelenideLogger.commitStep(SelenideLogger.beginStep("slider", message), targetOutOfBound);
+            throw UIAssertionError.wrap(WebDriverRunner.driver(), new AssertionError(message, targetOutOfBound), 0);
         }
     }
 

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -26,6 +26,7 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.impl.Html;
+import com.codeborne.selenide.impl.WebElementWrapper;
 import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
 import com.codeborne.selenide.logevents.SelenideLogger;
 
@@ -419,7 +420,8 @@ public class SelenideAddons
         catch (MoveTargetOutOfBoundsException targetOutOfBound)
         {
             String message = "Performing drag and drop with an element moved the element out of the viewport. Try to scroll the element completely into the view port or to decrease the absolute values of your movements.";
-
+            SelenideLogger.commitStep(SelenideLogger.beginStep("slider", message),
+                                      targetOutOfBound);
             throw UIAssertionError.wrap(WebDriverRunner.driver(),
                                         new AssertionError(message, targetOutOfBound),
                                         0);

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
@@ -26,7 +27,6 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.impl.Html;
-import com.codeborne.selenide.impl.WebElementWrapper;
 import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
 import com.codeborne.selenide.logevents.SelenideLogger;
 
@@ -422,9 +422,9 @@ public class SelenideAddons
             String message = "Performing drag and drop with an element moved the element out of the viewport. Try to scroll the element completely into the view port or to decrease the absolute values of your movements.";
             SelenideLogger.commitStep(SelenideLogger.beginStep("slider", message),
                                       targetOutOfBound);
-            throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                        new AssertionError(message, targetOutOfBound),
-                                        0);
+            throw new RuntimeException(UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                             new WebDriverException(message, targetOutOfBound),
+                                                             0));
         }
     }
 

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -418,12 +418,10 @@ public class SelenideAddons
         }
         catch (MoveTargetOutOfBoundsException targetOutOfBound)
         {
-            String parameterMessage = horizontalMovement != 0 ? (verticalMovement != 0 ? "'horizontalMovement' and 'verticalMovement'" : "'horizontalMovement'")
-                                                              : "'verticalMovement'";
+            String message = "Performing drag and drop with an element moved the element out of the viewport. Try to scroll the element completely into the view port or to decrease the absolute values of your movements.";
 
             throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                        new AssertionError("Target out of bounds. Try to decrease the absolute value of " + parameterMessage
-                                                           + " parameter", targetOutOfBound),
+                                        new AssertionError(message, targetOutOfBound),
                                         0);
         }
     }

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -536,6 +536,70 @@ public class SelenideAddonsTest
         slider.shouldHave(attribute("aria-valuenow", "14"));
     }
 
+    @Test()
+    public void testRightwardDragAndDropOutOfBounds()
+    {
+        openSliderPage();
+
+        SelenideElement slider = $(".balSlider a[role=slider]");
+        slider.shouldHave(attribute("aria-valuenow", "-10"));
+        AssertionError exception = Assert.assertThrows(AssertionError.class, () -> {
+            SelenideAddons.dragAndDrop(slider, 3200, 0);
+        });
+        String expectedMessage = "Target out of bounds. Try to decrease the absolute value of 'horizontalMovement' parameter";
+        String actualMessage = exception.getMessage();
+        Assert.assertTrue(String.format("The exception message %s doesn't contain the expected message %s", actualMessage, expectedMessage),
+                          actualMessage.contains(expectedMessage));
+    }
+
+    @Test()
+    public void testLeftwardDragAndDropOutOfBounds()
+    {
+        openSliderPage();
+
+        SelenideElement slider = $(".balSlider a[role=slider]");
+        slider.shouldHave(attribute("aria-valuenow", "-10"));
+        AssertionError exception = Assert.assertThrows(AssertionError.class, () -> {
+            SelenideAddons.dragAndDrop(slider, -3200, 0);
+        });
+        String expectedMessage = "Target out of bounds. Try to decrease the absolute value of 'horizontalMovement' parameter";
+        String actualMessage = exception.getMessage();
+        Assert.assertTrue(String.format("The exception message %s doesn't contain the expected message %s", actualMessage, expectedMessage),
+                          actualMessage.contains(expectedMessage));
+    }
+
+    @Test()
+    public void testUpwardDragAndDropOutOfBounds()
+    {
+        openSliderPage();
+
+        SelenideElement slider = $("#equalizer .k-slider-vertical:first-child a");
+        slider.shouldHave(attribute("aria-valuenow", "10"));
+        AssertionError exception = Assert.assertThrows(AssertionError.class, () -> {
+            SelenideAddons.dragAndDrop(slider, 0, -1200);
+        });
+        String expectedMessage = "Target out of bounds. Try to decrease the absolute value of 'verticalMovement' parameter";
+        String actualMessage = exception.getMessage();
+        Assert.assertTrue(String.format("The exception message %s doesn't contain the expected message %s", actualMessage, expectedMessage),
+                          actualMessage.contains(expectedMessage));
+    }
+
+    @Test()
+    public void testDownwardDragAndDropOutOfBounds()
+    {
+        openSliderPage();
+
+        SelenideElement slider = $("#equalizer .k-slider-vertical:first-child a");
+        slider.shouldHave(attribute("aria-valuenow", "10"));
+        AssertionError exception = Assert.assertThrows(AssertionError.class, () -> {
+            SelenideAddons.dragAndDrop(slider, 0, 1200);
+        });
+        String expectedMessage = "Target out of bounds. Try to decrease the absolute value of 'verticalMovement' parameter";
+        String actualMessage = exception.getMessage();
+        Assert.assertTrue(String.format("The exception message %s doesn't contain the expected message %s", actualMessage, expectedMessage),
+                          actualMessage.contains(expectedMessage));
+    }
+
     private void openSliderPage()
     {
         Selenide.open("https://demos.telerik.com/kendo-ui/slider/index");


### PR DESCRIPTION
The MoveTargetOutOfBoundsException is now catched and wrapped to UIAssertionError to take screenshot if exception is thrown. The suggestion is to decrease the absolute value of  `horizontalMovement` or/and  `verticalMovement` parameter.  If you have any better advice for user in this situation, please let me know.