### PR TITLE
#163 Test for Browserstack

### DIFF
--- a/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
+++ b/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
@@ -122,6 +122,7 @@ public class BrowserConfigurationMapper
         String emulatedPlatform = browserProfileConfiguration.get(PLATFORM);
         if (!StringUtils.isEmpty(emulatedPlatform))
             capabilities.setCapability(CapabilityType.PLATFORM, emulatedPlatform);
+            capabilities.setCapability("os", emulatedPlatform);
 
         String emulatedPlatformName = browserProfileConfiguration.get(PLATFORM_NAME);
         if (!StringUtils.isEmpty(emulatedPlatformName))
@@ -130,6 +131,7 @@ public class BrowserConfigurationMapper
         String emulatedVersion = browserProfileConfiguration.get(BROWSER_VERSION);
         if (!StringUtils.isEmpty(emulatedVersion))
             capabilities.setCapability(CapabilityType.VERSION, emulatedVersion);
+            capabilities.setCapability("browser_version", emulatedVersion);
 
         String emulatedDeviceName = browserProfileConfiguration.get(DEVICE_NAME);
         if (!StringUtils.isEmpty(emulatedDeviceName))

--- a/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
+++ b/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
@@ -126,11 +126,13 @@ public class BrowserConfigurationMapper
             // BrowserStack
             capabilities.setCapability("os", emulatedPlatform);
         }
+        
         String emulatedPlatformName = browserProfileConfiguration.get(PLATFORM_NAME);
         if (!StringUtils.isEmpty(emulatedPlatformName))
         {
             capabilities.setCapability(CapabilityType.PLATFORM_NAME, emulatedPlatformName);
         }
+        
         String emulatedVersion = browserProfileConfiguration.get(BROWSER_VERSION);
         if (!StringUtils.isEmpty(emulatedVersion))
         {
@@ -138,6 +140,7 @@ public class BrowserConfigurationMapper
             // BrowserStack
             capabilities.setCapability("browser_version", emulatedVersion);
         }
+        
         String emulatedDeviceName = browserProfileConfiguration.get(DEVICE_NAME);
         if (!StringUtils.isEmpty(emulatedDeviceName))
         {

--- a/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
+++ b/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
@@ -122,6 +122,7 @@ public class BrowserConfigurationMapper
         String emulatedPlatform = browserProfileConfiguration.get(PLATFORM);
         if (!StringUtils.isEmpty(emulatedPlatform))
             capabilities.setCapability(CapabilityType.PLATFORM, emulatedPlatform);
+            // BrwoserStack
             capabilities.setCapability("os", emulatedPlatform);
 
         String emulatedPlatformName = browserProfileConfiguration.get(PLATFORM_NAME);
@@ -131,6 +132,7 @@ public class BrowserConfigurationMapper
         String emulatedVersion = browserProfileConfiguration.get(BROWSER_VERSION);
         if (!StringUtils.isEmpty(emulatedVersion))
             capabilities.setCapability(CapabilityType.VERSION, emulatedVersion);
+            // BrowserStack
             capabilities.setCapability("browser_version", emulatedVersion);
 
         String emulatedDeviceName = browserProfileConfiguration.get(DEVICE_NAME);

--- a/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
+++ b/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
@@ -121,20 +121,23 @@ public class BrowserConfigurationMapper
          */
         String emulatedPlatform = browserProfileConfiguration.get(PLATFORM);
         if (!StringUtils.isEmpty(emulatedPlatform))
+        {
             capabilities.setCapability(CapabilityType.PLATFORM, emulatedPlatform);
-            // BrwoserStack
+            // BrowserStack
             capabilities.setCapability("os", emulatedPlatform);
-
+        }
         String emulatedPlatformName = browserProfileConfiguration.get(PLATFORM_NAME);
         if (!StringUtils.isEmpty(emulatedPlatformName))
+        {
             capabilities.setCapability(CapabilityType.PLATFORM_NAME, emulatedPlatformName);
-
+        }
         String emulatedVersion = browserProfileConfiguration.get(BROWSER_VERSION);
         if (!StringUtils.isEmpty(emulatedVersion))
+        {
             capabilities.setCapability(CapabilityType.VERSION, emulatedVersion);
             // BrowserStack
             capabilities.setCapability("browser_version", emulatedVersion);
-
+        }
         String emulatedDeviceName = browserProfileConfiguration.get(DEVICE_NAME);
         if (!StringUtils.isEmpty(emulatedDeviceName))
         {

--- a/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
+++ b/src/main/java/com/xceptance/neodymium/module/statement/browser/multibrowser/configuration/BrowserConfigurationMapper.java
@@ -131,6 +131,8 @@ public class BrowserConfigurationMapper
         if (!StringUtils.isEmpty(emulatedPlatformName))
         {
             capabilities.setCapability(CapabilityType.PLATFORM_NAME, emulatedPlatformName);
+            // BrowserStack
+            capabilities.setCapability("os", emulatedPlatformName);
         }
         
         String emulatedVersion = browserProfileConfiguration.get(BROWSER_VERSION);

--- a/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
@@ -25,7 +25,9 @@ public class BrowserstackHomePageTest
         // Goto the home page
         Selenide.open("https://www.xceptance.com/en/");
 
+        // verify the opened browser is safari browser via navigator object, which contains information about the browser
         Assert.assertTrue(Selenide.executeJavaScript("return navigator.userAgent.indexOf(\"Safari\")>-1;"));
+        
         // short validation to check that the correct page was opened, should be moved to OpenHomePageFlow
         $("#service-areas").should(exist);
         // basic validation

--- a/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
@@ -1,0 +1,52 @@
+package com.xceptance.neodymium.testclasses.multibrowser;
+
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.matchText;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.codeborne.selenide.Selenide;
+import com.xceptance.neodymium.NeodymiumRunner;
+import com.xceptance.neodymium.module.statement.browser.multibrowser.Browser;
+
+@RunWith(NeodymiumRunner.class)
+@Browser("safari_remote")
+public class BrowserstackHomePageTest
+{
+    @Test
+    public void testVisitingHomepage()
+    {
+        // Goto the home page
+        Selenide.open("https://www.xceptance.com/en/");
+
+        // short validation to check that the correct page was opened, should be moved to OpenHomePageFlow
+        $("#service-areas").should(exist);
+        // basic validation
+        // Verifies the company Logo and name are visible.
+        $("#navigation .navbar-brand a[title=Home]").shouldBe(visible);
+
+        // Verifies the Navigation bar is visible
+        $("#navigation .navbar-header ul.nav").shouldBe(visible);
+
+        // Asserts there's categories in the nav bar.
+        $$("#navigation .navbar-header ul.nav > li > a").shouldHave(sizeGreaterThan(0));
+
+        // Asserts the first headline is there.
+        $("#service-areas .landing-intro > h1").shouldBe(matchText("[A-Z].{3,}"));
+
+        // Asserts the animated carousel is there.
+        $("#myCarousel").shouldBe(visible);
+
+        // Verifies the "services" section is there.
+        // Asserts there's at least 1 item in the list.
+        $$("#service-areas .container .thumbnail").shouldHave(sizeGreaterThan(0));
+
+        // Verifies the company button is there.
+        $$("#xlt-background .container p.lead > a.btn-primary").shouldHave(sizeGreaterThan(0));
+    }
+}

--- a/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/multibrowser/BrowserstackHomePageTest.java
@@ -7,6 +7,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -15,7 +16,7 @@ import com.xceptance.neodymium.NeodymiumRunner;
 import com.xceptance.neodymium.module.statement.browser.multibrowser.Browser;
 
 @RunWith(NeodymiumRunner.class)
-@Browser("safari_remote")
+@Browser("Safari_Browserstack")
 public class BrowserstackHomePageTest
 {
     @Test
@@ -24,6 +25,7 @@ public class BrowserstackHomePageTest
         // Goto the home page
         Selenide.open("https://www.xceptance.com/en/");
 
+        Assert.assertTrue(Selenide.executeJavaScript("return navigator.userAgent.indexOf(\"Safari\")>-1;"));
         // short validation to check that the correct page was opened, should be moved to OpenHomePageFlow
         $("#service-areas").should(exist);
         // basic validation

--- a/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
@@ -23,7 +23,7 @@ public class BrowserstackTest extends NeodymiumTest
         Map<String, String> properties1 = new HashMap<>();
         properties1.put("browserprofile.testEnvironment.browserstack.url", "https://hub-cloud.browserstack.com/wd/hub");
         properties1.put("browserprofile.testEnvironment.browserstack.username", CONFIGURATION.browserstackUsername());
-        properties1.put("browserprofile.testEnvironment.browserstack.password", CONFIGURATION.browserstackApiKey());
+        properties1.put("browserprofile.testEnvironment.browserstack.password", CONFIGURATION.browserstackAccessKey());
         File tempConfigFile1 = new File("./config/credentials.properties");
         writeMapToPropertiesFile(properties1, tempConfigFile1);
         tempFiles.add(tempConfigFile1);

--- a/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
@@ -5,32 +5,36 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.aeonbits.owner.ConfigFactory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import com.xceptance.neodymium.testclasses.multibrowser.BrowserstackHomePageTest;
+import com.xceptance.neodymium.util.TestConfiguration;
 
 public class BrowserstackTest extends NeodymiumTest
 {
+    private static final TestConfiguration CONFIGURATION = ConfigFactory.create(TestConfiguration.class);
+
     @BeforeClass
     public static void beforeClass() throws IOException
     {
         Map<String, String> properties1 = new HashMap<>();
         properties1.put("browserprofile.testEnvironment.browserstack.url", "https://hub-cloud.browserstack.com/wd/hub");
-        properties1.put("browserprofile.testEnvironment.browserstack.username", System.getenv("BROWSERSTACK_USERNAME"));
-        properties1.put("browserprofile.testEnvironment.browserstack.password",  System.getenv("BROWSERSTACK_PASSWORD"));
+        properties1.put("browserprofile.testEnvironment.browserstack.username", CONFIGURATION.browserstackUsername());
+        properties1.put("browserprofile.testEnvironment.browserstack.password", CONFIGURATION.browserstackPassword());
         File tempConfigFile1 = new File("./config/credentials.properties");
         writeMapToPropertiesFile(properties1, tempConfigFile1);
         tempFiles.add(tempConfigFile1);
 
         Map<String, String> properties3 = new HashMap<>();
-        properties3.put("browserprofile.safari_remote.name", "safari_remote");
-        properties3.put("browserprofile.safari_remote.platform", "OS X");
-        properties3.put("browserprofile.safari_remote.platformVersion", "Big Sur");
-        properties3.put("browserprofile.safari_remote.browserName", "Safari");
-        properties3.put("browserprofile.safari_remote.version", "14.0");
-        properties3.put("browserprofile.safari_remote.testEnvironment", "browserstack");
+        properties3.put("browserprofile.Safari_Browserstack.name", "Safari Browserstack");
+        properties3.put("browserprofile.Safari_Browserstack.platform", "OS X");
+        properties3.put("browserprofile.Safari_Browserstack.platformVersion", "Big Sur");
+        properties3.put("browserprofile.Safari_Browserstack.browserName", "Safari");
+        properties3.put("browserprofile.Safari_Browserstack.version", "14.0");
+        properties3.put("browserprofile.Safari_Browserstack.testEnvironment", "browserstack");
         File tempConfigFile3 = new File("./config/dev-browser.properties");
         writeMapToPropertiesFile(properties3, tempConfigFile3);
         tempFiles.add(tempConfigFile3);

--- a/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
@@ -1,0 +1,45 @@
+package com.xceptance.neodymium.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import com.xceptance.neodymium.testclasses.multibrowser.BrowserstackHomePageTest;
+
+public class BrowserstackTest extends NeodymiumTest
+{
+    @BeforeClass
+    public static void beforeClass() throws IOException
+    {
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put("browserprofile.testEnvironment.browserstack.url", "https://hub-cloud.browserstack.com/wd/hub");
+        properties1.put("browserprofile.testEnvironment.browserstack.username", System.getenv("BROWSERSTACK_USERNAME"));
+        properties1.put("browserprofile.testEnvironment.browserstack.password",  System.getenv("BROWSERSTACK_PASSWORD"));
+        File tempConfigFile1 = new File("./config/credentials.properties");
+        writeMapToPropertiesFile(properties1, tempConfigFile1);
+        tempFiles.add(tempConfigFile1);
+
+        Map<String, String> properties3 = new HashMap<>();
+        properties3.put("browserprofile.safari_remote.name", "safari_remote");
+        properties3.put("browserprofile.safari_remote.platform", "OS X");
+        properties3.put("browserprofile.safari_remote.platformVersion", "Big Sur");
+        properties3.put("browserprofile.safari_remote.browserName", "Safari");
+        properties3.put("browserprofile.safari_remote.version", "14.0");
+        properties3.put("browserprofile.safari_remote.testEnvironment", "browserstack");
+        File tempConfigFile3 = new File("./config/dev-browser.properties");
+        writeMapToPropertiesFile(properties3, tempConfigFile3);
+        tempFiles.add(tempConfigFile3);
+    }
+
+    @Test
+    public void testBrowserstack()
+    {
+        Result result = JUnitCore.runClasses(BrowserstackHomePageTest.class);
+        checkPass(result, 1, 0);
+    }
+}

--- a/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
@@ -23,7 +23,7 @@ public class BrowserstackTest extends NeodymiumTest
         Map<String, String> properties1 = new HashMap<>();
         properties1.put("browserprofile.testEnvironment.browserstack.url", "https://hub-cloud.browserstack.com/wd/hub");
         properties1.put("browserprofile.testEnvironment.browserstack.username", CONFIGURATION.browserstackUsername());
-        properties1.put("browserprofile.testEnvironment.browserstack.password", CONFIGURATION.browserstackPassword());
+        properties1.put("browserprofile.testEnvironment.browserstack.password", CONFIGURATION.browserstackApiKey());
         File tempConfigFile1 = new File("./config/credentials.properties");
         writeMapToPropertiesFile(properties1, tempConfigFile1);
         tempFiles.add(tempConfigFile1);

--- a/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/BrowserstackTest.java
@@ -28,16 +28,16 @@ public class BrowserstackTest extends NeodymiumTest
         writeMapToPropertiesFile(properties1, tempConfigFile1);
         tempFiles.add(tempConfigFile1);
 
-        Map<String, String> properties3 = new HashMap<>();
-        properties3.put("browserprofile.Safari_Browserstack.name", "Safari Browserstack");
-        properties3.put("browserprofile.Safari_Browserstack.platform", "OS X");
-        properties3.put("browserprofile.Safari_Browserstack.platformVersion", "Big Sur");
-        properties3.put("browserprofile.Safari_Browserstack.browserName", "Safari");
-        properties3.put("browserprofile.Safari_Browserstack.version", "14.0");
-        properties3.put("browserprofile.Safari_Browserstack.testEnvironment", "browserstack");
-        File tempConfigFile3 = new File("./config/dev-browser.properties");
-        writeMapToPropertiesFile(properties3, tempConfigFile3);
-        tempFiles.add(tempConfigFile3);
+        Map<String, String> properties2 = new HashMap<>();
+        properties2.put("browserprofile.Safari_Browserstack.name", "Safari Browserstack");
+        properties2.put("browserprofile.Safari_Browserstack.platform", "OS X");
+        properties2.put("browserprofile.Safari_Browserstack.platformVersion", "Big Sur");
+        properties2.put("browserprofile.Safari_Browserstack.browserName", "Safari");
+        properties2.put("browserprofile.Safari_Browserstack.version", "14.0");
+        properties2.put("browserprofile.Safari_Browserstack.testEnvironment", "browserstack");
+        File tempConfigFile2 = new File("./config/dev-browser.properties");
+        writeMapToPropertiesFile(properties2, tempConfigFile2);
+        tempFiles.add(tempConfigFile2);
     }
 
     @Test

--- a/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
+++ b/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
@@ -17,6 +17,6 @@ public interface TestConfiguration extends Mutable
     @Key("BROWSERSTACK_USERNAME")
     public String browserstackUsername();
 
-    @Key("BROWSERSTACK_API_KEY")
-    public String browserstackApiKey();
+    @Key("BROWSERSTACK_ACCESS_KEY")
+    public String browserstackAccessKey();
 }

--- a/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
+++ b/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
@@ -1,0 +1,22 @@
+package com.xceptance.neodymium.util;
+
+import org.aeonbits.owner.Config.LoadPolicy;
+import org.aeonbits.owner.Config.LoadType;
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.Mutable;
+
+@LoadPolicy(LoadType.MERGE)
+@Sources(
+{
+  "system:env",
+  "system:properties",
+  "file:config/dev-testconfiguration.properties"
+})
+public interface TestConfiguration extends Mutable
+{
+    @Key("browserstack_username")
+    public String browserstackUsername();
+
+    @Key("browserstack_password")
+    public String browserstackPassword();
+}

--- a/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
+++ b/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
@@ -14,9 +14,9 @@ import org.aeonbits.owner.Mutable;
 })
 public interface TestConfiguration extends Mutable
 {
-    @Key("browserstack_username")
+    @Key("BROWSERSTACK_USERNAME")
     public String browserstackUsername();
 
-    @Key("browserstack_password")
+    @Key("BROWSERSTACK_PASSWORD")
     public String browserstackPassword();
 }

--- a/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
+++ b/src/test/java/com/xceptance/neodymium/util/TestConfiguration.java
@@ -17,6 +17,6 @@ public interface TestConfiguration extends Mutable
     @Key("BROWSERSTACK_USERNAME")
     public String browserstackUsername();
 
-    @Key("BROWSERSTACK_PASSWORD")
-    public String browserstackPassword();
+    @Key("BROWSERSTACK_API_KEY")
+    public String browserstackApiKey();
 }


### PR DESCRIPTION
There were some struggles while the configuration of the Safari browser to run on Browserstack. After some researchers, I realized, that the problem is caused by the fact, that some configurations were passed to Browserstack not correctly. The main misunderstanding was that "platform" capability for Browserstack means MAC/WIN/UNIX. This caused an error on passing "platform" and "platformVersion" parameters together. Instead, Browserstack required "os" capability, which can be passed together with "platformVersion". That's why I changed the capability name for the Browserstack. 

Further I've noticed, that browser version passed with "version" capability is not taken to attention by Browserstack, so I changed its name to "browser_version".