### PR TITLE
#181 improve catching sere

### DIFF
--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -239,7 +239,8 @@ public class SelenideAddons
             boolean containsMessage = false;
             for (String message : phrasesHintingErrorToCatch)
             {
-                if (t.getMessage().contains(message))
+                String messageText = t.getMessage();
+                if (messageText!=null && messageText.contains(message))
                 {
                     containsMessage = true;
                     break;

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -161,7 +161,7 @@ public class SelenideAddons
             catch (final Throwable t)
             {
                 if (isThrowableCausedBy(t, StaleElementReferenceException.class)
-                    || t.getMessage().contains("Actual value: StaleElementReferenceException: stale element refe"))
+                    || t.getMessage().contains("StaleElementReferenceException"))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -162,7 +162,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class) || t.getMessage().contains(SERE))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class, SERE))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)
@@ -219,12 +219,21 @@ public class SelenideAddons
         });
     }
 
-    public static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz)
+    public static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz, String... stringContainsMessage)
     {
         Throwable t = throwable;
         while (t != null)
         {
-            if (clazz.isInstance(t))
+            boolean containsMessage = false;
+            for (String message : stringContainsMessage)
+            {
+                containsMessage = t.getMessage().contains(message);
+                if (containsMessage)
+                {
+                    break;
+                }
+            }
+            if (clazz.isInstance(t) || containsMessage)
             {
                 return true;
             }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -35,6 +35,7 @@ import com.codeborne.selenide.logevents.SelenideLogger;
  */
 public class SelenideAddons
 {
+    private static final String SERE = StaleElementReferenceException.class.getSimpleName();
     /**
      * Returns an supplier that will return exactly one result if any. It will return an element that is found by
      * parentSelector and has a result for subElementSelector. It does NOT return the subelements, it is meant to be a
@@ -170,7 +171,7 @@ public class SelenideAddons
                     }
                     else
                     {
-                        AllureAddons.addToReport("StaleElementReferenceException catched times: \"" + retryCounter + "\".", retryCounter);
+                        AllureAddons.addToReport(SERE+" catched times: \"" + retryCounter + "\".", retryCounter);
                         Selenide.sleep(Neodymium.configuration().staleElementRetryTimeout());
                     }
                 }
@@ -233,7 +234,7 @@ public class SelenideAddons
                     }
                     else
                     {
-                        AllureAddons.addToReport("StaleElementReferenceException catched times: \"" + retryCounter + "\".", retryCounter);
+                        AllureAddons.addToReport(SERE+" catched times: \"" + retryCounter + "\".", retryCounter);
                         Selenide.sleep(Neodymium.configuration().staleElementRetryTimeout());
                     }
                 }
@@ -251,7 +252,7 @@ public class SelenideAddons
         Throwable t = throwable;
         while (t != null)
         {
-            if (clazz.isInstance(t) || t.getMessage().contains("StaleElementReferenceException"))
+            if (clazz.isInstance(t) || t.getMessage().contains(SERE))
             {
                 return true;
             }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -36,6 +36,7 @@ import com.codeborne.selenide.logevents.SelenideLogger;
 public class SelenideAddons
 {
     private static final String SERE = StaleElementReferenceException.class.getSimpleName();
+
     /**
      * Returns an supplier that will return exactly one result if any. It will return an element that is found by
      * parentSelector and has a result for subElementSelector. It does NOT return the subelements, it is meant to be a
@@ -171,7 +172,7 @@ public class SelenideAddons
                     }
                     else
                     {
-                        AllureAddons.addToReport(SERE+" catched times: \"" + retryCounter + "\".", retryCounter);
+                        AllureAddons.addToReport(SERE + " catched times: \"" + retryCounter + "\".", retryCounter);
                         Selenide.sleep(Neodymium.configuration().staleElementRetryTimeout());
                     }
                 }
@@ -212,39 +213,10 @@ public class SelenideAddons
      */
     public static void $safe(final Runnable code)
     {
-        final int maxRetryCount = Neodymium.configuration().staleElementRetryCount();
-        int retryCounter = 0;
-
-        while (retryCounter <= maxRetryCount)
-        {
-            try
-            {
-                code.run();
-                break;
-            }
-            catch (final Throwable t)
-            {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
-                {
-                    retryCounter++;
-                    if (retryCounter > maxRetryCount)
-                    {
-                        // fail
-                        throw t;
-                    }
-                    else
-                    {
-                        AllureAddons.addToReport(SERE+" catched times: \"" + retryCounter + "\".", retryCounter);
-                        Selenide.sleep(Neodymium.configuration().staleElementRetryTimeout());
-                    }
-                }
-                else
-                {
-                    // not the kind of error we are looking for
-                    throw t;
-                }
-            }
-        }
+        $safe(()->{
+            code.run();
+            return null;
+        });
     }
 
     private static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz)

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -160,7 +160,8 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class)
+                    || t.getMessage().contains("Actual value: StaleElementReferenceException: stale element refe"))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)
@@ -414,7 +415,8 @@ public class SelenideAddons
         try
         {
             // perform drag and drop via the standard Selenium way
-            new Actions(Neodymium.getDriver()).dragAndDropBy(elementToMove.getWrappedElement(), horizontalMovement, verticalMovement).build().perform();
+            new Actions(Neodymium.getDriver()).dragAndDropBy(elementToMove.getWrappedElement(), horizontalMovement, verticalMovement)
+                                              .build().perform();
         }
         catch (MoveTargetOutOfBoundsException targetOutOfBound)
         {
@@ -443,8 +445,8 @@ public class SelenideAddons
      * @param condition
      *            The condition for the slider to verify the movement
      */
-    public static void dragAndDropUntilCondition(SelenideElement elementToMove, SelenideElement elementToCheck, int horizontalMovement, int verticalMovement,
-                                                 int pauseBetweenMovements, int retryMovements, Condition condition)
+    public static void dragAndDropUntilCondition(SelenideElement elementToMove, SelenideElement elementToCheck, int horizontalMovement,
+                                                 int verticalMovement, int pauseBetweenMovements, int retryMovements, Condition condition)
     {
         int counter = 0;
         while (!elementToCheck.has(condition))

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -162,7 +162,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class) || t.getMessage().contains(SERE))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)
@@ -213,18 +213,18 @@ public class SelenideAddons
      */
     public static void $safe(final Runnable code)
     {
-        $safe(()->{
+        $safe(() -> {
             code.run();
             return null;
         });
     }
 
-    private static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz)
+    public static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz)
     {
         Throwable t = throwable;
         while (t != null)
         {
-            if (clazz.isInstance(t) || t.getMessage().contains(SERE))
+            if (clazz.isInstance(t))
             {
                 return true;
             }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -160,8 +160,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class)
-                    || t.getMessage().contains("StaleElementReferenceException"))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)
@@ -224,7 +223,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class) || t.getMessage().contains("StaleElementReferenceException"))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)
@@ -252,7 +251,7 @@ public class SelenideAddons
         Throwable t = throwable;
         while (t != null)
         {
-            if (clazz.isInstance(t))
+            if (clazz.isInstance(t) || t.getMessage().contains("StaleElementReferenceException"))
             {
                 return true;
             }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -239,9 +239,9 @@ public class SelenideAddons
             boolean containsMessage = false;
             for (String message : phrasesHintingErrorToCatch)
             {
-                containsMessage = t.getMessage().contains(message);
-                if (containsMessage)
+                if (t.getMessage().contains(message))
                 {
+                    containsMessage = true;
                     break;
                 }
             }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -219,13 +219,25 @@ public class SelenideAddons
         });
     }
 
-    public static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz, String... stringContainsMessage)
+    /**
+     * Recursively checks if the throwable is caused by exception of the specific class or contains one of the messages
+     * listed in the {@code phrasesHintingErrorToCatch}
+     * 
+     * @param throwable
+     *            throwable to check
+     * @param clazz
+     *            class of the expected throwable cause
+     * @param phrasesHintingErrorToCatch
+     *            optional parameters, error messages of expected throwable or its causes
+     * @return result of the check as boolean value
+     */
+    public static boolean isThrowableCausedBy(final Throwable throwable, Class<? extends Throwable> clazz, String... phrasesHintingErrorToCatch)
     {
         Throwable t = throwable;
         while (t != null)
         {
             boolean containsMessage = false;
-            for (String message : stringContainsMessage)
+            for (String message : phrasesHintingErrorToCatch)
             {
                 containsMessage = t.getMessage().contains(message);
                 if (containsMessage)

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -224,7 +224,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class))
+                if (isThrowableCausedBy(t, StaleElementReferenceException.class) || t.getMessage().contains("StaleElementReferenceException"))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.UIAssertionError;
@@ -311,7 +312,8 @@ public class SelenideAddonsTest
                      });
         runArray.add(
                      () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(), new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n" + 
+                             "Actual value: StaleElementReferenceException: stale element refe"), 0);
                      });
         runArray.add(
                      () -> {

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -396,7 +396,7 @@ public class SelenideAddonsTest
         // real duration for cause check is mostly only few seconds more than minimal duration, although the duration of
         // message check is always approximately 1000ms more due to UIAssertion wrapping
         long maximalDuration = minimalDuration + 1000;
-        Assert.assertTrue("Wating time taken to catch SERE (" + duration + "ms) is not in range from  " + minimalDuration + " to " + maximalDuration + "ms",
+        Assert.assertTrue("Waiting time taken to catch SERE (" + duration + "ms) is not in range from  " + minimalDuration + " to " + maximalDuration + "ms",
                           Range.between(minimalDuration, maximalDuration).contains(duration));
 
         Assert.assertEquals("SERE was catched " + counter.get() + " times instead of " + (Neodymium.configuration().staleElementRetryCount() + 1),

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -319,14 +319,12 @@ public class SelenideAddonsTest
     }
 
     @Test()
-    @SuppressBrowsers
     public void testSafeRunnableInCause()
     {
         testSafe(runArrayWithSEREinCause, false);
     }
 
     @Test()
-    @SuppressBrowsers
     public void testSafeRunnableInMessage()
     {
         testSafe(runArrayWithSEREinMessage, false);

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -76,7 +76,7 @@ public class SelenideAddonsTest
         }
     };
 
-    List<Runnable> runArrayWithSEREinCause = new ArrayList<Runnable>()
+    private List<Runnable> runArrayWithSEREinCause = new ArrayList<Runnable>()
     {
         private static final long serialVersionUID = 2L;
         {
@@ -389,10 +389,16 @@ public class SelenideAddonsTest
         {
             Assert.assertTrue(e.getMessage() + " doesn't contain phrase 'You shall pass!'", e.getMessage().contains("You shall pass!"));
         }
-        long endTime = new Date().getTime();
-        Assert.assertTrue("Wating time taken to catch SERE (" + (endTime - startTime) + ") is less than " + Neodymium.configuration().staleElementRetryTimeout()
-                          + " milliseconds as expected",
-                          endTime - startTime > Neodymium.configuration().staleElementRetryTimeout());
+
+        long duration = new Date().getTime() - startTime;
+
+        long minimalDuration = Neodymium.configuration().staleElementRetryTimeout() * Neodymium.configuration().staleElementRetryCount();
+        // real duration for cause check is mostly only few seconds more than minimal duration, although the duration of
+        // message check is always approximately 1000ms more due to UIAssertion wrapping
+        long maximalDuration = minimalDuration + 1000;
+        Assert.assertTrue("Wating time taken to catch SERE (" + duration + "ms) is not in range from  " + minimalDuration + " to " + maximalDuration + "ms",
+                          Range.between(minimalDuration, maximalDuration).contains(duration));
+
         Assert.assertEquals("SERE was catched " + counter.get() + " times instead of " + (Neodymium.configuration().staleElementRetryCount() + 1),
                             Neodymium.configuration().staleElementRetryCount() + 1, counter.get());
 

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -311,11 +311,28 @@ public class SelenideAddonsTest
 
     @Test()
     @SuppressBrowsers
+    public void testIsThrowableNotCausedBy()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
+        Assert.assertFalse("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, NumberFormatException.class));
+    }
+
+    @Test()
+    @SuppressBrowsers
     public void testIsThrowableCausedByMessage()
     {
         Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
         Assert.assertTrue("Throwable has unexpected cause",
-                          SelenideAddons.isThrowableCausedBy(causedByIOException, NullPointerException.class, "this is assertion error"));
+                          SelenideAddons.isThrowableCausedBy(causedByIOException, NumberFormatException.class, "this is assertion error"));
+    }
+
+    @Test()
+    @SuppressBrowsers
+    public void testIsThrowableNotCausedByMessage()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
+        Assert.assertFalse("Throwable has unexpected cause",
+                          SelenideAddons.isThrowableCausedBy(causedByIOException, NumberFormatException.class, "not existing message"));
     }
 
     @Test()

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -38,6 +38,71 @@ import com.xceptance.neodymium.module.statement.browser.multibrowser.SuppressBro
 @Browser("Chrome_headless")
 public class SelenideAddonsTest
 {
+    private List<Runnable> runArrayWithSEREinMessage = new ArrayList<Runnable>()
+    {
+        {
+            add(
+                () -> {
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                   +
+                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                0);
+                });
+            add(
+                () -> {
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                   +
+                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                0);
+                });
+            add(
+                () -> {
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                   +
+                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                0);
+                });
+            add(
+                () -> {
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(), new AssertionError("You shall pass!"), 0);
+                });
+            add(
+                () -> {
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                new AssertionError("You shall never be seen in StaleElementReferenceException catch function!"), 0);
+                });
+        }
+    };
+
+    List<Runnable> runArrayWithSEREinCause = new ArrayList<Runnable>()
+    {
+        {
+            add(
+                () -> {
+                    throw new StaleElementReferenceException("You shall not pass!");
+                });
+            add(
+                () -> {
+                    throw new StaleElementReferenceException("You shall not pass!");
+                });
+            add(
+                () -> {
+                    throw new StaleElementReferenceException("You shall not pass!");
+                });
+            add(
+                () -> {
+                    throw new StaleElementReferenceException("You shall pass!");
+                });
+            add(
+                () -> {
+                    throw new StaleElementReferenceException("You shall never be seen!");
+                });
+        }
+    };
+
     private void openBlogPage()
     {
         Selenide.open("https://blog.xceptance.com/");
@@ -240,165 +305,42 @@ public class SelenideAddonsTest
     @SuppressBrowsers
     public void testSafeRunnableInCause()
     {
-        // preparing the test setup as kind of generator
-        List<Runnable> runArray = new ArrayList<Runnable>();
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall never be seen!");
-                     });
-        testSafeRunnable(runArray);
+        testSafe(runArrayWithSEREinCause, false);
     }
 
     @Test()
     @SuppressBrowsers
     public void testSafeRunnableInMessage()
     {
-        // preparing the test setup as kind of generator
-        List<Runnable> runArray = new ArrayList<Runnable>();
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall never be seen!");
-                     });
-        testSafeRunnable(runArray);
+        testSafe(runArrayWithSEREinMessage, false);
     }
 
     @Test()
     public void testSafeSupplierInCause()
     {
-        List<Runnable> runArray = new ArrayList<Runnable>();
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                        +
-                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
-                                                     0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall never be seen!");
-                     });
-        testSafeSupplier(runArray);
+        testSafe(runArrayWithSEREinCause, true);
     }
 
     @Test()
     public void testSafeSupplierInMessage()
     {
-        List<Runnable> runArray = new ArrayList<Runnable>();
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall never be seen!");
-                     });
-        testSafeSupplier(runArray);
+        testSafe(runArrayWithSEREinMessage, true);
     }
 
-    private void testSafeRunnable(List<Runnable> runArray)
+    private SelenideElement testSupplier(AtomicInteger counter, Iterator<Runnable> iterator)
     {
-        // preparing the test setup as kind of generator
-        AtomicInteger counter = new AtomicInteger(0);
-        final Iterator<Runnable> iterator = runArray.iterator();
+        return SelenideAddons.$safe(() -> {
+            counter.incrementAndGet();
+            if (iterator.hasNext())
+            {
+                iterator.next().run();
+            }
+            return $("body").should(exist);
+        });
+    }
 
-        // testing the error path after three exceptions
-        long startTime = new Date().getTime();
-        try
-        {
-            SelenideAddons.$safe(() -> {
-                counter.incrementAndGet();
-                if (iterator.hasNext())
-                {
-                    iterator.next().run();
-                }
-            });
-        }
-        catch (StaleElementReferenceException e)
-        {
-            Assert.assertTrue(e.getMessage().startsWith("You shall pass!"));
-        }
-        long endTime = new Date().getTime();
-        Assert.assertTrue(endTime - startTime > Neodymium.configuration().staleElementRetryTimeout());
-        Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 1);
-
-        // testing the happy path after one exception
+    private void testRunnable(AtomicInteger counter, Iterator<Runnable> iterator)
+    {
         SelenideAddons.$safe(() -> {
             counter.incrementAndGet();
             if (iterator.hasNext())
@@ -406,10 +348,9 @@ public class SelenideAddonsTest
                 iterator.next().run();
             }
         });
-        Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 3);
     }
 
-    private void testSafeSupplier(List<Runnable> runArray)
+    private void testSafe(List<Runnable> runArray, boolean isSupplier)
     {
         // preparing the test setup as kind of generator
         AtomicInteger counter = new AtomicInteger(0);
@@ -420,34 +361,30 @@ public class SelenideAddonsTest
         long startTime = new Date().getTime();
         try
         {
-            SelenideAddons.$safe(() -> {
-                counter.incrementAndGet();
-                if (iterator.hasNext())
-                {
-                    iterator.next().run();
-                }
-                return $("body").should(exist);
-            });
+            if (isSupplier)
+            {
+                testSupplier(counter, iterator);
+            }
+            else
+            {
+                testRunnable(counter, iterator);
+            }
         }
-        catch (StaleElementReferenceException e)
+        catch (StaleElementReferenceException | UIAssertionError e)
         {
-            Assert.assertTrue(e.getMessage().startsWith("You shall pass!"));
+            Assert.assertTrue(e.getMessage().contains("You shall pass!"));
         }
         long endTime = new Date().getTime();
         Assert.assertTrue(endTime - startTime > Neodymium.configuration().staleElementRetryTimeout());
         Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 1);
 
-        // testing the happy path after one exception
-        SelenideElement element = SelenideAddons.$safe(() -> {
-            counter.incrementAndGet();
-            if (iterator.hasNext())
-            {
-                iterator.next().run();
-            }
-            return $("body");
-        });
-        Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 3);
-        element.shouldBe(visible);
+        if (isSupplier)
+        {
+            // testing the happy path after one exception
+            SelenideElement element = testSupplier(counter, iterator);
+            Assert.assertEquals(Neodymium.configuration().staleElementRetryCount() + 3, counter.get());
+            element.shouldBe(visible);
+        }
     }
 
     @Test()

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.Range;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -386,17 +387,21 @@ public class SelenideAddonsTest
         }
         catch (StaleElementReferenceException | UIAssertionError e)
         {
-            Assert.assertTrue(e.getMessage().contains("You shall pass!"));
+            Assert.assertTrue(e.getMessage() + " doesn't contain phrase 'You shall pass!'", e.getMessage().contains("You shall pass!"));
         }
         long endTime = new Date().getTime();
-        Assert.assertTrue(endTime - startTime > Neodymium.configuration().staleElementRetryTimeout());
-        Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 1);
+        Assert.assertTrue("Wating time taken to catch SERE (" + (endTime - startTime) + ") is less than " + Neodymium.configuration().staleElementRetryTimeout()
+                          + " milliseconds as expected",
+                          endTime - startTime > Neodymium.configuration().staleElementRetryTimeout());
+        Assert.assertEquals("SERE was catched " + counter.get() + " times instead of " + (Neodymium.configuration().staleElementRetryCount() + 1),
+                            Neodymium.configuration().staleElementRetryCount() + 1, counter.get());
 
         if (isSupplier)
         {
             // testing the happy path after one exception
             SelenideElement element = testSupplier(counter, iterator);
-            Assert.assertEquals(Neodymium.configuration().staleElementRetryCount() + 3, counter.get());
+            Assert.assertEquals("SERE was catched " + counter.get() + " times instead of " + (Neodymium.configuration().staleElementRetryCount() + 3),
+                                Neodymium.configuration().staleElementRetryCount() + 3, counter.get());
             element.shouldBe(visible);
         }
     }

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -302,18 +302,20 @@ public class SelenideAddonsTest
     }
 
     @Test()
+    @SuppressBrowsers
     public void testIsThrowableCausedBy()
     {
-        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
-        Assert.assertTrue("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class));
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
+        Assert.assertTrue("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, NullPointerException.class));
     }
 
     @Test()
+    @SuppressBrowsers
     public void testIsThrowableCausedByMessage()
     {
-        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
         Assert.assertTrue("Throwable has unexpected cause",
-                          SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class, "this is assertion error"));
+                          SelenideAddons.isThrowableCausedBy(causedByIOException, NullPointerException.class, "this is assertion error"));
     }
 
     @Test()

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -6,6 +6,7 @@ import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
@@ -323,6 +324,13 @@ public class SelenideAddonsTest
     public void testSafeSupplierInMessage()
     {
         testSafe(runArrayWithSEREinMessage, true);
+    }
+
+    @Test()
+    public void testIsThrowableCausedBy()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception",new AssertionError("this is assertion error", new IOException("this is final cause")));
+        SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class);
     }
 
     private SelenideElement testSupplier(AtomicInteger counter, Iterator<Runnable> iterator)

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -314,7 +314,8 @@ public class SelenideAddonsTest
     public void testIsThrowableNotCausedBy()
     {
         Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new NullPointerException("this is final cause")));
-        Assert.assertFalse("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, NumberFormatException.class));
+        Assert.assertFalse("Throwable has unexpected cause",
+                           SelenideAddons.isThrowableCausedBy(causedByIOException, NumberFormatException.class, "not existing message"));
     }
 
     @Test()

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -329,8 +329,16 @@ public class SelenideAddonsTest
     @Test()
     public void testIsThrowableCausedBy()
     {
-        Throwable causedByIOException = new RuntimeException("This is runtime exception",new AssertionError("this is assertion error", new IOException("this is final cause")));
-        SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class);
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
+        Assert.assertTrue("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class));
+    }
+
+    @Test()
+    public void testIsThrowableCausedByMessage()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
+        Assert.assertTrue("Throwable has unexpected cause",
+                          SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class, "this is assertion error"));
     }
 
     private SelenideElement testSupplier(AtomicInteger counter, Iterator<Runnable> iterator)

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -40,6 +40,7 @@ public class SelenideAddonsTest
 {
     private List<Runnable> runArrayWithSEREinMessage = new ArrayList<Runnable>()
     {
+        private static final long serialVersionUID = 1L;
         {
             add(
                 () -> {
@@ -75,6 +76,7 @@ public class SelenideAddonsTest
 
     List<Runnable> runArrayWithSEREinCause = new ArrayList<Runnable>()
     {
+        private static final long serialVersionUID = 2L;
         {
             add(
                 () -> {

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -238,10 +238,9 @@ public class SelenideAddonsTest
 
     @Test()
     @SuppressBrowsers
-    public void testSafeRunnable()
+    public void testSafeRunnableInCause()
     {
         // preparing the test setup as kind of generator
-        AtomicInteger counter = new AtomicInteger(0);
         List<Runnable> runArray = new ArrayList<Runnable>();
         runArray.add(
                      () -> {
@@ -263,6 +262,120 @@ public class SelenideAddonsTest
                      () -> {
                          throw new StaleElementReferenceException("You shall never be seen!");
                      });
+        testSafeRunnable(runArray);
+    }
+
+    @Test()
+    @SuppressBrowsers
+    public void testSafeRunnableInMessage()
+    {
+        // preparing the test setup as kind of generator
+        List<Runnable> runArray = new ArrayList<Runnable>();
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall never be seen!");
+                     });
+        testSafeRunnable(runArray);
+    }
+
+    @Test()
+    public void testSafeSupplierInCause()
+    {
+        List<Runnable> runArray = new ArrayList<Runnable>();
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                     new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
+                                                                        +
+                                                                        "Actual value: StaleElementReferenceException: stale element refe"),
+                                                     0);
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall never be seen!");
+                     });
+        testSafeSupplier(runArray);
+    }
+
+    @Test()
+    public void testSafeSupplierInMessage()
+    {
+        List<Runnable> runArray = new ArrayList<Runnable>();
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall not pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall not pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall not pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall pass!");
+                     });
+        runArray.add(
+                     () -> {
+                         throw new StaleElementReferenceException("You shall never be seen!");
+                     });
+        testSafeSupplier(runArray);
+    }
+
+    private void testSafeRunnable(List<Runnable> runArray)
+    {
+        // preparing the test setup as kind of generator
+        AtomicInteger counter = new AtomicInteger(0);
         final Iterator<Runnable> iterator = runArray.iterator();
 
         // testing the error path after three exceptions
@@ -296,33 +409,10 @@ public class SelenideAddonsTest
         Assert.assertEquals(counter.get(), Neodymium.configuration().staleElementRetryCount() + 3);
     }
 
-    @Test()
-    public void testSafeSupplier()
+    private void testSafeSupplier(List<Runnable> runArray)
     {
         // preparing the test setup as kind of generator
         AtomicInteger counter = new AtomicInteger(0);
-        List<Runnable> runArray = new ArrayList<Runnable>();
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall not pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw UIAssertionError.wrap(WebDriverRunner.driver(), new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n" + 
-                             "Actual value: StaleElementReferenceException: stale element refe"), 0);
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall pass!");
-                     });
-        runArray.add(
-                     () -> {
-                         throw new StaleElementReferenceException("You shall never be seen!");
-                     });
         final Iterator<Runnable> iterator = runArray.iterator();
 
         // testing the error path after three exceptions

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -302,6 +302,21 @@ public class SelenideAddonsTest
     }
 
     @Test()
+    public void testIsThrowableCausedBy()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
+        Assert.assertTrue("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class));
+    }
+
+    @Test()
+    public void testIsThrowableCausedByMessage()
+    {
+        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
+        Assert.assertTrue("Throwable has unexpected cause",
+                          SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class, "this is assertion error"));
+    }
+
+    @Test()
     @SuppressBrowsers
     public void testSafeRunnableInCause()
     {
@@ -325,21 +340,6 @@ public class SelenideAddonsTest
     public void testSafeSupplierInMessage()
     {
         testSafe(runArrayWithSEREinMessage, true);
-    }
-
-    @Test()
-    public void testIsThrowableCausedBy()
-    {
-        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
-        Assert.assertTrue("Throwable has unexpected cause", SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class));
-    }
-
-    @Test()
-    public void testIsThrowableCausedByMessage()
-    {
-        Throwable causedByIOException = new RuntimeException("This is runtime exception", new AssertionError("this is assertion error", new IOException("this is final cause")));
-        Assert.assertTrue("Throwable has unexpected cause",
-                          SelenideAddons.isThrowableCausedBy(causedByIOException, IOException.class, "this is assertion error"));
     }
 
     private SelenideElement testSupplier(AtomicInteger counter, Iterator<Runnable> iterator)

--- a/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
+++ b/src/test/java/com/xceptance/neodymium/util/SelenideAddonsTest.java
@@ -44,30 +44,26 @@ public class SelenideAddonsTest
             add(
                 () -> {
                     throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                   +
-                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                new AssertionError("StaleElementReferenceException"),
                                                 0);
                 });
             add(
                 () -> {
                     throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                   +
-                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                new AssertionError("WeCanStillSpotTheStaleElementReferenceExceptionEvenIfItTriesToHide"),
                                                 0);
                 });
             add(
                 () -> {
                     throw UIAssertionError.wrap(WebDriverRunner.driver(),
-                                                new AssertionError(" value displayed:StaleElementReferenceException: stale element reference: element is not attached to the page document>StaleElementReferenceException: stale element reference: element is not attached to the page document</StaleElementReferenceException: stale element reference: element is not attached to the page document>'\n"
-                                                                   +
-                                                                   "Actual value: StaleElementReferenceException: stale element refe"),
+                                                new AssertionError("We think this was caused by an :StaleElementReferenceException"),
                                                 0);
                 });
             add(
                 () -> {
-                    throw UIAssertionError.wrap(WebDriverRunner.driver(), new AssertionError("You shall pass!"), 0);
+                    throw UIAssertionError.wrap(WebDriverRunner.driver(),
+                                                new AssertionError("You shall pass! Even though you contain the word StaleElementReferenceException that we are searching for."),
+                                                0);
                 });
             add(
                 () -> {


### PR DESCRIPTION
In some of our projects, we have seen SERE being thrown while retrieving the actual display status of the element. In this case, the exception doesn't contain SERE as a cause but only mentions it in the error message. 

The changes are meant to catch such exceptions too. This PR also contains changes for `SelenideAddonsTest.testSafeSupplier`, which are meant to test the new `$safe` method behavior.