### PR TITLE
#179 Filter test methods for execution by regex from configuration file

### DIFF
--- a/config/neodymium.properties
+++ b/config/neodymium.properties
@@ -96,6 +96,9 @@
 # The following long value will be use to initialize Neodymiums Random instance.  
 # neodymium.context.random.initialValue = 123456789
 #
+# Using this option you can filter the test to be executed by class name, method name and data set id
+# neodymium.testNameFilter = .*
+#
 #############################
 #
 # JavaScriptUtils properties

--- a/config/neodymium.properties
+++ b/config/neodymium.properties
@@ -97,7 +97,7 @@
 # neodymium.context.random.initialValue = 123456789
 #
 # Using this option you can filter the test to be executed by class name, method name and data set id
-# neodymium.testNameFilter = .*
+# neodymium.testNameFilter = 
 #
 #############################
 #

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -167,7 +167,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
             {
                 // for the case, when the property was set accidentally, inform the user about such behavior reason via
                 // warning in logs
-                LOGGER.warn("The test class " + testClassInstance.getClass() + " will not be executed as none of its methods match regex '"
+                LOGGER.error("The test class " +getName()+ " will not be executed as none of its methods match regex '"
                             + testExecutionRegex + "'. In case this is not the behaviour you expected,"
                             + " please check your neodymium.properties for neodymium.testExecutionRegex configuration"
                             + " and your maven surefire settings for the corresponding system property");

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -146,6 +146,9 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
         return testClassInstance;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void validateInstanceMethods(List<Throwable> errors)
     {
@@ -167,7 +170,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
             {
                 // for the case, when the property was set accidentally, inform the user about such behavior reason via
                 // warning in logs
-                LOGGER.warn("The test class " +getName()+ " will not be executed as none of its methods match regex '"
+                LOGGER.warn("The test class " + getName() + " will not be executed as none of its methods match regex '"
                             + testExecutionRegex + "'. In case this is not the behaviour you expected,"
                             + " please check your neodymium.properties for neodymium.testNameFilter configuration"
                             + " and your maven surefire settings for the corresponding system property");

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -162,7 +162,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
             String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
 
             // only throw exception if test class has no execution methods accidentally
-            if (testExecutionRegex == null)
+            if (StringUtils.isNotEmpty(testExecutionRegex))
             {
                 errors.add(new Exception("No runnable methods"));
             }

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.Description;
@@ -240,7 +241,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
 
         // filter test methods by regex
         String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
-        if (testExecutionRegex != null)
+        if (StringUtils.isNoneEmpty(testExecutionRegex))
         {
             testMethods = testMethods.stream()
                                      .filter(testMethod -> {

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -167,7 +167,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
             {
                 // for the case, when the property was set accidentally, inform the user about such behavior reason via
                 // warning in logs
-                LOGGER.error("The test class " +getName()+ " will not be executed as none of its methods match regex '"
+                LOGGER.warn("The test class " +getName()+ " will not be executed as none of its methods match regex '"
                             + testExecutionRegex + "'. In case this is not the behaviour you expected,"
                             + " please check your neodymium.properties for neodymium.testExecutionRegex configuration"
                             + " and your maven surefire settings for the corresponding system property");

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -241,7 +241,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
 
         // filter test methods by regex
         String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
-        if (StringUtils.isNoneEmpty(testExecutionRegex))
+        if (StringUtils.isNotEmpty(testExecutionRegex))
         {
             testMethods = testMethods.stream()
                                      .filter(testMethod -> {

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -7,7 +7,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runner.notification.RunNotifier;
@@ -144,6 +147,35 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
     }
 
     @Override
+    protected void validateInstanceMethods(List<Throwable> errors)
+    {
+        validatePublicVoidNoArgMethods(After.class, false, errors);
+        validatePublicVoidNoArgMethods(Before.class, false, errors);
+        validateTestMethods(errors);
+        if (computeTestMethods().isEmpty())
+        {
+            String testExecutionRegex = Neodymium.configuration().getTestExecutionRegex();
+
+            // only throw exception if test class has no execution methods accidentally
+            if (testExecutionRegex == null)
+            {
+                errors.add(new Exception("No runnable methods"));
+            }
+            // in case the neodymium.testExecutionRegex is set, it's assumes, that the test methods are ignored on
+            // purpose
+            else
+            {
+                // for the case, when the property was set accidentally, inform the user about such behavior reason via
+                // warning in logs
+                LOGGER.warn("The test class " + testClassInstance.getClass() + " will not be executed as none of its methods match regex '"
+                            + testExecutionRegex + "'. In case this is not the behaviour you expected,"
+                            + " please check your neodymium.properties for neodymium.testExecutionRegex configuration"
+                            + " and your maven surefire settings for the corresponding system property");
+            }
+        }
+    }
+
+    @Override
     protected List<FrameworkMethod> computeTestMethods()
     {
         // Normally JUnit works with all methods that are annotated with @Test, see super's implementation
@@ -200,6 +232,16 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
 
             // This is the point where multiple test methods are computed for the current processed method.
             testMethods.addAll(buildCrossProduct(testAnnotatedMethod.getMethod(), builderList, builderDataList));
+        }
+
+        // filter test methods by regex
+        String testExecutionRegex = Neodymium.configuration().getTestExecutionRegex();
+        if (testExecutionRegex != null)
+        {
+            testMethods = testMethods.stream()
+                                     .filter(testMethod -> (testMethod.getMethod().getDeclaringClass() + "#"
+                                                            + testMethod.getName()).matches(testExecutionRegex))
+                                     .collect(Collectors.toList());
         }
 
         // this list is now final for class execution so make it unmodifiable

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -154,14 +154,14 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
         validateTestMethods(errors);
         if (computeTestMethods().isEmpty())
         {
-            String testExecutionRegex = Neodymium.configuration().getTestExecutionRegex();
+            String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
 
             // only throw exception if test class has no execution methods accidentally
             if (testExecutionRegex == null)
             {
                 errors.add(new Exception("No runnable methods"));
             }
-            // in case the neodymium.testExecutionRegex is set, it's assumes, that the test methods are ignored on
+            // in case the neodymium.testNameFilter is set, it's assumes, that the test methods are ignored on
             // purpose
             else
             {
@@ -169,7 +169,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
                 // warning in logs
                 LOGGER.warn("The test class " +getName()+ " will not be executed as none of its methods match regex '"
                             + testExecutionRegex + "'. In case this is not the behaviour you expected,"
-                            + " please check your neodymium.properties for neodymium.testExecutionRegex configuration"
+                            + " please check your neodymium.properties for neodymium.testNameFilter configuration"
                             + " and your maven surefire settings for the corresponding system property");
             }
         }
@@ -235,7 +235,7 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
         }
 
         // filter test methods by regex
-        String testExecutionRegex = Neodymium.configuration().getTestExecutionRegex();
+        String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
         if (testExecutionRegex != null)
         {
             testMethods = testMethods.stream()

--- a/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumRunner.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -242,8 +243,13 @@ public class NeodymiumRunner extends BlockJUnit4ClassRunner
         if (testExecutionRegex != null)
         {
             testMethods = testMethods.stream()
-                                     .filter(testMethod -> (testMethod.getMethod().getDeclaringClass() + "#"
-                                                            + testMethod.getName()).matches(testExecutionRegex))
+                                     .filter(testMethod -> {
+                                         String functionName = testMethod.getMethod().getDeclaringClass().getName() + "#"
+                                                               + testMethod.getName();
+                                         return Pattern.compile(testExecutionRegex)
+                                                       .matcher(functionName)
+                                                       .find();
+                                     })
                                      .collect(Collectors.toList());
         }
 

--- a/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
+++ b/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
@@ -258,4 +258,6 @@ public interface NeodymiumConfiguration extends Mutable
     @Key("neodymium.webDriver.opera.pathToBrowser")
     public String getOperaBrowserPath();
 
+    @Key("neodymium.testExecutionRegex")
+    public String getTestExecutionRegex();
 }

--- a/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
+++ b/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
@@ -258,6 +258,6 @@ public interface NeodymiumConfiguration extends Mutable
     @Key("neodymium.webDriver.opera.pathToBrowser")
     public String getOperaBrowserPath();
 
-    @Key("neodymium.testExecutionRegex")
-    public String getTestExecutionRegex();
+    @Key("neodymium.testNameFilter")
+    public String getTestNameFilter();
 }

--- a/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
@@ -1,0 +1,38 @@
+package com.xceptance.neodymium.testclasses.filtering;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.xceptance.neodymium.NeodymiumRunner;
+import com.xceptance.neodymium.module.statement.testdata.SuppressDataSets;
+import com.xceptance.neodymium.util.DataUtils;
+
+import io.cucumber.java.it.Data;
+
+@RunWith(NeodymiumRunner.class)
+public class TestCaseFiltering
+{
+
+    @Test
+    @Data("id=executable")
+    public void shouldBeExecuted()
+    {
+        Assert.assertTrue("This test should be executed", true);
+    }
+
+    @Test
+    @SuppressDataSets
+    public void shouldNotBeExecuted()
+    {
+        Assert.assertTrue("This test should not be executed", false);
+    }
+
+    @Test
+    public void shouldBeExecutedForDataSetWithExecutableId()
+    {
+        Assert.assertEquals("This test should only be executed for data set with id 'executable'", "executable",
+                            DataUtils.asString("testId"));
+    }
+
+}

--- a/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
@@ -18,6 +18,8 @@ public class TestCaseFiltering
     public void shouldBeExecuted()
     {
         Assert.assertTrue("This test should be executed", true);
+        Assert.assertEquals("This test should only be executed for data set with id 'executable'", "executable",
+                            DataUtils.asString("testId"));
     }
 
     @Test

--- a/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
+++ b/src/test/java/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.java
@@ -13,7 +13,6 @@ import io.cucumber.java.it.Data;
 @RunWith(NeodymiumRunner.class)
 public class TestCaseFiltering
 {
-
     @Test
     @Data("id=executable")
     public void shouldBeExecuted()
@@ -34,5 +33,4 @@ public class TestCaseFiltering
         Assert.assertEquals("This test should only be executed for data set with id 'executable'", "executable",
                             DataUtils.asString("testId"));
     }
-
 }

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -22,8 +22,9 @@ public class TestCaseFilteringTest extends NeodymiumTest
         final String fileLocation = "config/test-filtering-neodymium.properties";
 
         Map<String, String> properties = new HashMap<>();
-        properties.put("neodymium.testNameFilter", ".*#(shouldBeExecuted|shouldBeExecutedForDataSetWithExecutableId) :: executable.*");
-
+        properties.put("neodymium.testNameFilter",
+                       "TestCaseFiltering#(shouldBeExecuted|shouldBeExecutedForDataSetWithExecutableId) :: executable");
+       
         File tempConfigFile = new File("./" + fileLocation);
         writeMapToPropertiesFile(properties, tempConfigFile);
         tempFiles.add(tempConfigFile);

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -22,8 +22,7 @@ public class TestCaseFilteringTest extends NeodymiumTest
         final String fileLocation = "config/test-filtering-neodymium.properties";
 
         Map<String, String> properties = new HashMap<>();
-
-        properties.put("neodymium.testNameFilter", ".*#shouldBeExecuted.*::\\\\sexecutable.*");
+        properties.put("neodymium.testNameFilter", ".*#(shouldBeExecuted|shouldBeExecutedForDataSetWithExecutableId) :: executable.*");
 
         File tempConfigFile = new File("./" + fileLocation);
         writeMapToPropertiesFile(properties, tempConfigFile);

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -34,7 +34,7 @@ public class TestCaseFilteringTest extends NeodymiumTest
     @Test
     public void testTestCaseFiltering()
     {
-        // the test from RandomBrowserChild should be run 2 times, as the corresponding annotations should be inherited
+        // the test from RandomBrowserChild should run 2 times, as the corresponding annotations should be inherited
         // from the RandomBrowserParent class
         Result result = JUnitCore.runClasses(TestCaseFiltering.class);
         checkPass(result, 2, 0);

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -1,0 +1,44 @@
+package com.xceptance.neodymium.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+
+import com.xceptance.neodymium.testclasses.filtering.TestCaseFiltering;
+import com.xceptance.neodymium.util.Neodymium;
+
+public class TestCaseFilteringTest extends NeodymiumTest
+{
+    @BeforeClass
+    public static void beforeClass() throws IOException
+    {
+        final String fileLocation = "config/test-filtering-neodymium.properties";
+
+        Map<String, String> properties = new HashMap<>();
+
+        properties.put("neodymium.testExecutionRegex", ".*#shouldBeExecuted.*::\\\\sexecutable.*");
+
+        File tempConfigFile = new File("./" + fileLocation);
+        writeMapToPropertiesFile(properties, tempConfigFile);
+        tempFiles.add(tempConfigFile);
+
+        ConfigFactory.setProperty(Neodymium.TEMPORARY_CONFIG_FILE_PROPERTY_NAME, "file:" + fileLocation);
+    }
+
+    @Test
+    public void testTestCaseFiltering()
+    {
+        // the test from RandomBrowserChild should be run 2 times, as the corresponding annotations should be inherited
+        // from the RandomBrowserParent class
+        Result result = JUnitCore.runClasses(TestCaseFiltering.class);
+        checkPass(result, 2, 0);
+    }
+
+}

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -40,5 +40,4 @@ public class TestCaseFilteringTest extends NeodymiumTest
         Result result = JUnitCore.runClasses(TestCaseFiltering.class);
         checkPass(result, 2, 0);
     }
-
 }

--- a/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
+++ b/src/test/java/com/xceptance/neodymium/tests/TestCaseFilteringTest.java
@@ -23,7 +23,7 @@ public class TestCaseFilteringTest extends NeodymiumTest
 
         Map<String, String> properties = new HashMap<>();
 
-        properties.put("neodymium.testExecutionRegex", ".*#shouldBeExecuted.*::\\\\sexecutable.*");
+        properties.put("neodymium.testNameFilter", ".*#shouldBeExecuted.*::\\\\sexecutable.*");
 
         File tempConfigFile = new File("./" + fileLocation);
         writeMapToPropertiesFile(properties, tempConfigFile);

--- a/src/test/resources/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.json
+++ b/src/test/resources/com/xceptance/neodymium/testclasses/filtering/TestCaseFiltering.json
@@ -1,0 +1,8 @@
+[
+  {
+    "testId": "executable"
+  },
+  {
+    "testId": "not executable"
+  }
+]


### PR DESCRIPTION
The changes in `NeodymiumRunner.computeTestMethods` are meant to filter the test methods by applying the regex from the `neodymium.testExecutionRegex` on the already generated method description.

To avoid redundant error message for the tests, which should not be executed, the `validateInstanceMethods` of `BlockJUnit4ClassRunner` was overridden to ignore the test classes with no runnable methods if the `neodymium.testExecutionRegex` is configured. 

The feature allows to filter test cases for execution via neodymium property like the following:
`neodymium.testExecutionRegex=".*LoginTest#testLoginWithPasswordFailure\s::\swrong\spassword.*"`
( This is not obligatory to mention all the parts of the test description. If you don't want to specify the part, simply replace it with `.*`)

More useful, however, might be passing this property for specific maven profile like here:
```xml
<profiles>
   <profile>
      <id>missing</id>
      <activation>
         <activeByDefault>true</activeByDefault>
      </activation>
      <build>
         <plugins>
            <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
                  <systemProperties>
                     <property>
                        <name>neodymium.testExecutionRegex</name>
                        <value>.*LoginTest#testLoginWithoutRequiredFields\s::\smissing\spassword.*</value>
                     </property>
                  </systemProperties>
               </configuration>
            </plugin>
         </plugins>
      </build>
   </profile>
   <profile>
      <id>wrong</id>
      <build>
         <plugins>
            <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
                  <systemProperties>
                     <property>
                        <name>neodymium.testExecutionRegex</name>
                        <value>.*LoginTest#testLoginWithPasswordFailure\s::\swrong\spassword.*</value>
                     </property>
                  </systemProperties>
               </configuration>
            </plugin>
         </plugins>
      </build>
   </profile>
</profiles>
```