### PR TITLE
Logging backend and configuration #253

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,24 +375,22 @@
 			<version>2.0.12</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>2.0.13</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
 			<version>${log4j.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>${log4j.version}</version>
+      <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
After the change is introduced, the projects without configured logging will see errors in logs. So we should not forget to configure logging in the neodymium-template and neodymium-example