### PR TITLE
[#263] Bug: StaleElementException Log

### DIFF
--- a/src/main/java/com/xceptance/neodymium/NeodymiumWebDriverListener.java
+++ b/src/main/java/com/xceptance/neodymium/NeodymiumWebDriverListener.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.events.WebDriverListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.xceptance.neodymium.util.DebugUtils;
 import com.xceptance.neodymium.util.Neodymium;
@@ -11,31 +13,73 @@ import com.xceptance.neodymium.util.SelenideAddons;
 
 public class NeodymiumWebDriverListener implements WebDriverListener
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NeodymiumWebDriverListener.class);
+
     @Override
     public void beforeFindElement(WebDriver driver, By by)
     {
-        DebugUtils.injectHighlightingJs();
-        DebugUtils.highlightAllElements(by, driver);
+        try
+        {
+            if (Neodymium.configuration().debuggingHighlightSelectedElements())
+            {
+                DebugUtils.injectHighlightingJs();
+                DebugUtils.highlightAllElements(by, driver);
+            }
+        }
+        catch (Throwable e)
+        {
+            LOGGER.warn("Could not find element to highlight. If you don't need the highlight, please set the neodymium.debugUtils.highlight to false", e);
+        }
     }
 
     @Override
     public void beforeFindElements(WebDriver driver, By by)
     {
-        DebugUtils.injectHighlightingJs();
-        DebugUtils.highlightAllElements(by, driver);
+        try
+        {
+            if (Neodymium.configuration().debuggingHighlightSelectedElements())
+            {
+                DebugUtils.injectHighlightingJs();
+                DebugUtils.highlightAllElements(by, driver);
+            }
+        }
+        catch (Throwable e)
+        {
+            LOGGER.warn("Could not find element to highlight. If you don't need the highlight, please set the neodymium.debugUtils.highlight to false", e);
+        }
     }
 
     @Override
     public void beforeFindElement(WebElement element, By locator)
     {
-        DebugUtils.injectHighlightingJs();
-        SelenideAddons.$safe(() -> DebugUtils.highlightAllElements(element.findElements(locator), Neodymium.getDriver()));
+        try
+        {
+            if (Neodymium.configuration().debuggingHighlightSelectedElements())
+            {
+                DebugUtils.injectHighlightingJs();
+                SelenideAddons.$safe(() -> DebugUtils.highlightAllElements(element.findElements(locator), Neodymium.getDriver()));
+            }
+        }
+        catch (Throwable e)
+        {
+            LOGGER.warn("Could not find element to highlight. If you don't need the highlight, please set the neodymium.debugUtils.highlight to false", e);
+        }
     }
 
     @Override
     public void beforeFindElements(WebElement element, By locator)
     {
-        DebugUtils.injectHighlightingJs();
-        SelenideAddons.$safe(() -> DebugUtils.highlightAllElements(element.findElements(locator), Neodymium.getDriver()));
+        try
+        {
+            if (Neodymium.configuration().debuggingHighlightSelectedElements())
+            {
+                DebugUtils.injectHighlightingJs();
+                SelenideAddons.$safe(() -> DebugUtils.highlightAllElements(element.findElements(locator), Neodymium.getDriver()));
+            }
+        }
+        catch (Throwable e)
+        {
+            LOGGER.warn("Could not find element to highlight. If you don't need the highlight, please set the neodymium.debugUtils.highlight to false", e);
+        }
     }
 }

--- a/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
+++ b/src/main/java/com/xceptance/neodymium/util/SelenideAddons.java
@@ -165,7 +165,7 @@ public class SelenideAddons
             }
             catch (final Throwable t)
             {
-                if (isThrowableCausedBy(t, StaleElementReferenceException.class, SERE))
+                if (t instanceof StaleElementReferenceException || isThrowableCausedBy(t, StaleElementReferenceException.class, SERE))
                 {
                     retryCounter++;
                     if (retryCounter > maxRetryCount)


### PR DESCRIPTION
tried to improve catching SERE but it doesn't work for 100%. Also made the search for the element happen only if the element highlight is actually desired (otherwise it makes no sense and only makes tests slowly). Also added a custom warning log in case an element cannot be found, when highlighting is actually turned on (users who didn't know that highlighting was on and don't need it, will get rid of these logs and those who knew, can debug better)