### PR TITLE
[387] configure REST client timeout, added properties and documentation

### DIFF
--- a/config/xtc-api.properties
+++ b/config/xtc-api.properties
@@ -1,6 +1,59 @@
+# Enable uploading test results and reports to XTC
+xtc.api.enable = false
+
+# Organization and project to identify the project in XTC
 xtc.api.organization = xc
 xtc.api.project = neo-example
+
+# Secrets for the XTC API access
+# ATTENTION: should NOT be defined here, instead move it to dev-xtc-api.properties or dev-credentials.properties
 xtc.api.key =
-xtc.api.secret = 
+xtc.api.secret =
+
+# The scope of the API key in XTC
+xtc.api.scope = TESTEXECUTION_CREATE TESTEXECUTION_FINISH TESTEXECUTION_LIST TESTEXECUTION_REPORT_UPLOAD TESTEXECUTION_UPDATE
+
+# Name and profile for the test run - to identify the test run easier
+xtc.api.name = ${xtc.api.project} local test run ${xtc.api.buildNumber}
 xtc.api.profile = local test run
+
+# Pipeline link, build number and test instance to add CICD metadata
+xtc.api.pipelineLink = https://example.com/pipeline/${xtc.api.buildNumber}
+xtc.api.buildNumber = 42
+xtc.api.testInstance = local-test-instance
+
+# Description for the test run
 xtc.api.description = test run for local development
+
+# The estimated duration in minutes - gives XTC an estimated duration
+xtc.api.estimatedDuration = 1
+
+# Controls the REST client
+# number of retires for each REST call
+xtc.api.numberOfRetries = 3
+# initial delay between retries in milliseconds
+xtc.api.retryDelay = 1000
+# timeout for the REST client to create the run, update the results and upload the report
+xtc.api.timeout = 30000
+
+# Controls the error handling for REST calls
+# throw an exception when the run could not be created
+xtc.api.throwExceptionForRunCreationError = true
+# throw an exception when the run could not be updated
+xtc.api.throwExceptionForRunUpdateError = true
+# throw an exception when the report could not be uploaded
+xtc.api.throwExceptionForReportUploadError = true
+
+# Defines the result directories
+# define the suredire result directory - used to get the test statistics
+xtc.api.surefireResultDirectory = target/surefire-reports
+# define the allure result directory - currently not used but maybe later to enable the report history
+xtc.api.allureResultDirectory = target/allure-results
+# define the allure report directory - containing the generated allure report used to upload it
+xtc.api.allureReportDirectory = target/site/allure-maven-plugin
+
+# throws an exception if something is not configured correctly
+xtc.api.validateConfigurationWithException = false
+
+# if true, throws an exception if the XTC API is disabled - prevent accidentally turning it off
+xtc.api.throwExceptionForRunInitialization = false

--- a/src/main/java/com/xceptance/neodymium/common/xtc/ResultProcessor.java
+++ b/src/main/java/com/xceptance/neodymium/common/xtc/ResultProcessor.java
@@ -20,16 +20,11 @@ import java.util.zip.GZIPOutputStream;
 // parses the results of the tests and uploads them to XTC using the XTC API client
 public class ResultProcessor
 {
-    // The directories for the surefire reports and allure results are set via command line arguments
     private static String surefireReportsDir = XtcApiContext.configuration.xtcApiSurefireResultDirectory();
 
-    private static String allureResultsDir = XtcApiContext.configuration.xtcApiAllureResultDirectory(); // not necessary not, but most likely when updating the test run results during the test run
+    private static String allureResultsDir = XtcApiContext.configuration.xtcApiAllureResultDirectory(); // not necessary now, but most likely when updating the test results during the test run
 
     private static String allureReportDir = XtcApiContext.configuration.xtcApiAllureReportDirectory();
-
-    private static final String DEFAULT_RESULTS_DIRECTORIES = System.lineSeparator() + "--surefire-dir=${project.build.directory}/surefire-reports" +
-        System.lineSeparator() + "--allure-dir=${project.build.directory}/allure-results" +
-        System.lineSeparator() + "--allure-report-dir=${project.build.directory}/site/allure-maven-plugin";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultProcessor.class);
 
@@ -43,6 +38,15 @@ public class ResultProcessor
             return;
         }
 
+        if (System.getProperty("xtc.run.id") == null)
+        {
+            LOGGER.error("Run ID is not set in system properties. Please run RunInitializer first to create a test run.");
+            throw new RuntimeException("Run ID is not set in system properties. Please run RunInitializer first to create a test run.");
+        }
+
+        int runId = Integer.parseInt(System.getProperty("xtc.run.id"));
+        LOGGER.info("Run ID: {}", runId);
+
         LOGGER.info("Surefire reports directory: {}", surefireReportsDir);
         LOGGER.info("Allure results directory: {}", allureResultsDir);
         LOGGER.info("Allure report directory: {}", allureReportDir);
@@ -52,15 +56,6 @@ public class ResultProcessor
 
         // read the run ID from the system properties
         LOGGER.info("Reading run ID from system properties...");
-
-        if (System.getProperty("xtc.run.id") == null)
-        {
-            LOGGER.error("Run ID is not set in system properties. Please run RunInitializer first to create a test run.");
-            throw new RuntimeException("Run ID is not set in system properties. Please run RunInitializer first to create a test run.");
-        }
-
-        int runId = Integer.parseInt(System.getProperty("xtc.run.id"));
-        LOGGER.info("Run ID: {}", runId);
 
         updateTestRunResults(xtcApiClient, runId);
         uploadAllureReport(xtcApiClient, runId);

--- a/src/main/java/com/xceptance/neodymium/common/xtc/RunInitializer.java
+++ b/src/main/java/com/xceptance/neodymium/common/xtc/RunInitializer.java
@@ -21,10 +21,10 @@ public class RunInitializer
         {
             LOGGER.info("XTC API is disabled. Exiting...");
 
-            if (XtcApiContext.configuration.xtcApiThrowExceptionForRunCreationError())
+            if (XtcApiContext.configuration.xtcApiThrowExceptionForRunInitialization())
             {
                 throw new RuntimeException("XTC API is disabled and exception asserting this is enabled. Please enable the XTC API in the configuration. " +
-                                               "Otherwise, the run will not be created. If this is intended, disable the 'xtc.api.throwExceptionForRunCreationError' " +
+                                               "Otherwise, the run will not be created. If this is intended, disable the 'xtc.api.xtcApiThrowExceptionForRunInitialization' " +
                                                "configuration option.");
             }
 

--- a/src/main/java/com/xceptance/neodymium/common/xtc/XtcApiClient.java
+++ b/src/main/java/com/xceptance/neodymium/common/xtc/XtcApiClient.java
@@ -31,7 +31,7 @@ public class XtcApiClient
     private final TokenManager tokenManager;
 
     private final HttpClient client = HttpClient.newBuilder()
-                                                .connectTimeout(Duration.ofSeconds(300))
+                                                .connectTimeout(Duration.ofMillis(XtcApiContext.configuration.xtcApiTimeout()))
                                                 .build();
 
     private final Gson gson = new GsonBuilder().serializeNulls().create();

--- a/src/main/java/com/xceptance/neodymium/common/xtc/config/XtcApiConfiguration.java
+++ b/src/main/java/com/xceptance/neodymium/common/xtc/config/XtcApiConfiguration.java
@@ -80,12 +80,16 @@ public interface XtcApiConfiguration extends Mutable
     @DefaultValue("30000")
     public int xtcApiTimeout();
 
+    @Key("xtc.api.throwExceptionForRunInitialization")
+    @DefaultValue("false")
+    public boolean xtcApiThrowExceptionForRunInitialization();
+
     @Key("xtc.api.throwExceptionForRunCreationError")
     @DefaultValue("true")
     public boolean xtcApiThrowExceptionForRunCreationError();
 
     @Key("xtc.api.throwExceptionForRunUpdateError")
-    @DefaultValue("true")
+    @DefaultValue("false")
     public boolean xtcApiThrowExceptionForRunUpdateError();
 
     @Key("xtc.api.throwExceptionForReportUploadError")


### PR DESCRIPTION
- made REST client timeout configurable via properties
- added all XTC properties with documentation
- check the runId earlier to break the execution faster 