### PR TITLE
Support legacy devtools v 137

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,5 +490,10 @@
 			<artifactId>jsonassert</artifactId>
 			<version>2.0-rc1</version>
 		</dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-devtools-v137</artifactId>
+      <version>4.35.0</version>
+    </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Due to update to newer Selenide version, Neodymium stops to provide dependency for devtools v137 but many projects still use this dependency and it's still valid to use. Therefore, we add the dependency here to provide legacy support for the devtools version